### PR TITLE
Fix gcc warning

### DIFF
--- a/pgpcre.c
+++ b/pgpcre.c
@@ -137,10 +137,10 @@ matches_internal(text *subject, pgpcre *pattern, char ***return_matches, int *nu
 
 	if (num_captured)
 	{
-		int rc;
+		int rc0;
 
-		if ((rc = pcre_fullinfo(pc, NULL, PCRE_INFO_CAPTURECOUNT, &num_substrings)) != 0)
-			elog(ERROR, "pcre_fullinfo error: %d", rc);
+		if ((rc0 = pcre_fullinfo(pc, NULL, PCRE_INFO_CAPTURECOUNT, &num_substrings)) != 0)
+			elog(ERROR, "pcre_fullinfo error: %d", rc0);
 	}
 
 	if (return_matches)


### PR DESCRIPTION
45.14 pgpcre.c: In function 'matches_internal':
45.14 pgpcre.c:140:21: warning: declaration of 'rc' shadows a previous local [-Wshadow=compatible-local]
45.14   140 |                 int rc;
45.14       |                     ^~
45.14 pgpcre.c:118:33: note: shadowed declaration is here
45.14   118 |         int                     rc;
45.14       |                                 ^~